### PR TITLE
Rewriting SSM parameter code

### DIFF
--- a/AwAws/Lambda/extensions.py
+++ b/AwAws/Lambda/extensions.py
@@ -4,6 +4,13 @@ import signal
 import sys
 import requests
 
+'''
+This is the base class for lambda extensions.  The actual extensions can be found in the top
+level /extensions directory.  Extensions can be used to initialize objects and data before
+the lambda starts running as well as handing logging or other types of error reporting without
+affecting the code in the lambda itself 
+'''
+
 
 class Extension:
     def __init__(self):
@@ -36,7 +43,7 @@ class Extension:
         print(f"[{self.name}] Registered with ID: {self.extension_id}", flush=True)
 
     def process_events(self):
-        'this listens for events from lambda'
+        'this listens for events from the lambda service'
         url = f"http://{self.lambda_api}/2020-01-01/extension/event/next"
         headers = {
             'Lambda-Extension-Identifier': self.extension_id
@@ -57,11 +64,11 @@ class Extension:
                 self.event_processing(event)
 
     def event_processing(self, event):
-        'do something with the event'
+        'runs on every lambda invoke event - override this function to do something more interesting'
         print(f'[{self.name}] Received event: {json.dumps(event)}', flush=True)
 
     def exit_processing(self):
-        'do something when the function exits'
+        'do something when the function exits - override this to do something more interesting'
         print(f'[{self.name}] Received SHUTDOWN event. Exiting!', flush=True)
         sys.exit(0)
 

--- a/AwAws/Lambda/extensions.py
+++ b/AwAws/Lambda/extensions.py
@@ -8,7 +8,7 @@ import requests
 This is the base class for lambda extensions.  The actual extensions can be found in the top
 level /extensions directory.  Extensions can be used to initialize objects and data before
 the lambda starts running as well as handing logging or other types of error reporting without
-affecting the code in the lambda itself 
+affecting the code in the lambda itself
 '''
 
 

--- a/AwAws/Lambda/extensions.py
+++ b/AwAws/Lambda/extensions.py
@@ -64,7 +64,7 @@ class Extension:
                 self.event_processing(event)
 
     def event_processing(self, event):
-        'runs on every lambda invoke event - override this function to do something more interesting'
+        'runs on every lambda invoke event - override function to do something more interesting'
         print(f'[{self.name}] Received event: {json.dumps(event)}', flush=True)
 
     def exit_processing(self):

--- a/AwAws/SharedResources/parameters.py
+++ b/AwAws/SharedResources/parameters.py
@@ -1,4 +1,4 @@
-import pickle
+import pickle  # nosec - safe inside lambda environment
 
 from AwAws.Session.session import Session
 
@@ -85,11 +85,11 @@ class Parameters:
         'store key/value pairs in a tmp file (for lambda)'
         params = self.get_param_dictionary()
         file = open(self.tmp_file_loc, 'wb')
-        pickle.dump(params, file)
+        pickle.dump(params, file)  # nosec - safe inside a lambda
         file.close()
 
     def read_tmp_dict(self):
         'read tmp file and return contents'
         file = open(self.tmp_file_loc, 'rb')
-        params = pickle.load(file)
+        params = pickle.load(file)  # nosec - safe inside a lambda
         return params

--- a/AwAws/SharedResources/parameters.py
+++ b/AwAws/SharedResources/parameters.py
@@ -1,3 +1,5 @@
+import pickle
+
 from AwAws.Session.session import Session
 
 
@@ -5,13 +7,21 @@ class Parameters:
     'parameters are store as <service>.<param> = value'
     def __init__(self, service, region_name=None, role_arn=None):
         self.service = service
-        self.ssm = Session(region_name, role_arn).get_client('ssm')
+        self.region_name = region_name
+        self.role_arn = role_arn
+        self.tmp_file_loc = '/tmp/awaws_ssm_params'
+        self.ssm = None
+
+    def get_ssm(self):
+        if self.ssm is None:
+            self.ssm = Session(self.region_name, self.role_arn).get_client('ssm')
+        return self.ssm
 
     def get_param(self, name=None):
         'returns a specific parameter from service'
         fqn = self.fully_qualified_parameter_name(name)
         try:
-            response = self.ssm.get_parameter(
+            response = self.get_ssm().get_parameter(
                 Name=fqn,
                 WithDecryption=True
             )
@@ -26,7 +36,7 @@ class Parameters:
         'returns all of the params related to this service'
         service_root = self.fully_qualified_parameter_name('')
         try:
-            response = self.ssm.get_parameters_by_path(
+            response = self.get_ssm().get_parameters_by_path(
                 Path=service_root,
                 WithDecryption=True
             )
@@ -40,6 +50,14 @@ class Parameters:
             ret_params[name] = param
         return ret_params
 
+    def get_param_dictionary(self):
+        'returns all the params as key/value pairs'
+        params = self.get_all()
+        param_dict = {}
+        for name in params.keys():
+            param_dict[name] = params[name]['Value']
+        return param_dict
+
     def put_param(self, name, value, secure=None):
         'stores a parameter in the SSM parameter store'
         fqn = self.fully_qualified_parameter_name(name)
@@ -50,7 +68,7 @@ class Parameters:
             param_type = 'StringList'
 
         try:
-            response = self.ssm.put_parameter(
+            response = self.get_ssm().put_parameter(
                 Name=fqn,
                 Value=value,
                 Type=param_type,
@@ -62,3 +80,16 @@ class Parameters:
 
     def fully_qualified_parameter_name(self, name):
         return '/'.join(['', self.service, name])
+
+    def create_tmp_dict(self):
+        'store key/value pairs in a tmp file (for lambda)'
+        params = self.get_param_dictionary()
+        file = open(self.tmp_file_loc, 'wb')
+        pickle.dump(params, file)
+        file.close()
+
+    def read_tmp_dict(self):
+        'read tmp file and return contents'
+        file = open(self.tmp_file_loc, 'rb')
+        params = pickle.load(file)
+        return params

--- a/extensions/ssm_params
+++ b/extensions/ssm_params
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-import json
 import os
-import pickle
 import sys
 
 # These need to be imported from /opt/python
@@ -17,12 +15,9 @@ class SSMParamsExtension(Extension):
         self.service = None
         super().__init__()
 
-    def get_params(self):
+    def store_params(self):
         try:
-            params = Parameters(self.service).get_all()
-            file = open('/tmp/ssm_params', 'wb')
-            pickle.dump(params, file)
-            file.close()
+            Parameters(self.service).create_tmp_dict()
             print(f'[{self.name}] SSM params found for {self.service}')
         except Exception as e:
             print(f'[{self.name}] No SSM params found for {self.service} - check SSM', e)
@@ -43,7 +38,7 @@ ext.register_extension()
 # This extension only runs in the init stage
 ext.service = Env().get_env('AWAWS_SSM_SERVICE')
 if ext.service is not None:
-    ext.get_params()
+    ext.store_params()
 else:
     print(f'AWAWS_SSM_SERVICE is required for SSM caching - ssm parameter caching turned off')
 

--- a/tests/SharedResources/test_parameters.py
+++ b/tests/SharedResources/test_parameters.py
@@ -48,12 +48,22 @@ def ssm_put_response():
 def test_init():
     params = Parameters(service='test_service')
     inspect.isclass(Parameters)
-    assert str(type(params.ssm)) == "<class 'botocore.client.SSM'>"
     assert params.service == 'test_service'
+    assert params.region_name is None
+    assert params.role_arn is None
+    assert params.tmp_file_loc == '/tmp/awaws_ssm_params'
+    assert params.ssm is None
+
+
+def test_get_ssm():
+    params = Parameters(service='test_service')
+    params.get_ssm()
+    assert str(type(params.ssm)) == "<class 'botocore.client.SSM'>"
 
 
 def test_get_param(ssm_get_response):
     params = Parameters(service='alpha')
+    params.get_ssm()
     with Stubber(params.ssm) as stubber:
         stubber.add_response('get_parameter', ssm_get_response)
         assert params.get_param('hostname')['Value'] == 'some.hostname.com'
@@ -61,6 +71,7 @@ def test_get_param(ssm_get_response):
 
 def test_get_param_value(ssm_get_response):
     params = Parameters(service='alpha')
+    params.get_ssm()
     with Stubber(params.ssm) as stubber:
         stubber.add_response('get_parameter', ssm_get_response)
         assert params.get_param_value('hostname') == 'some.hostname.com'
@@ -68,6 +79,7 @@ def test_get_param_value(ssm_get_response):
 
 def test_get_fail():
     params = Parameters(service='omega')
+    params.get_ssm()
     with Stubber(params.ssm) as stubber:
         stubber.add_client_error('get_parameter')
         with pytest.raises(RuntimeError):
@@ -76,6 +88,7 @@ def test_get_fail():
 
 def test_get_all(ssm_get_all_response):
     params = Parameters(service='test_service')
+    params.get_ssm()
     with Stubber(params.ssm) as stubber:
         stubber.add_response('get_parameters_by_path', ssm_get_all_response)
         my_params = params.get_all()
@@ -85,6 +98,7 @@ def test_get_all(ssm_get_all_response):
 
 def test_put_param(ssm_put_response):
     params = Parameters(service='alpha')
+    params.get_ssm()
     with Stubber(params.ssm) as stubber:
         stubber.add_response('put_parameter', ssm_put_response)
         stubber.add_response('put_parameter', ssm_put_response)
@@ -94,6 +108,7 @@ def test_put_param(ssm_put_response):
 
 def test_put_fail():
     params = Parameters(service='omega')
+    params.get_ssm()
     with Stubber(params.ssm) as stubber:
         stubber.add_client_error('put_parameter')
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
The main goal here is to make this module more efficient when being used in lambda
The new version will write parameters out to a temporary file.  This can be done in the init stage of a lambda extension which will run before the lambda is executed.   When the lambda runs, it will load this module but just read from the temp file WITHOUT needing to create a botocore session - so should be pretty fast.